### PR TITLE
Change xmap signature for better type-inference

### DIFF
--- a/boopickle/shared/src/main/scala/boopickle/CompositePicklers.scala
+++ b/boopickle/shared/src/main/scala/boopickle/CompositePicklers.scala
@@ -41,7 +41,7 @@ case class CompositePickler[A <: AnyRef](var picklers: Vector[(String, Pickler[_
   }
 
   def addTransform[B <: A, C](transformTo: (B) => C, transformFrom: (C) => B)(implicit p: Pickler[C], tag: ClassTag[B]) = {
-    val pickler = p.map(transformTo)(transformFrom)
+    val pickler = p.xmap(transformFrom)(transformTo)
     picklers :+= (tag.runtimeClass.getName -> pickler)
     this
   }

--- a/boopickle/shared/src/main/scala/boopickle/Default.scala
+++ b/boopickle/shared/src/main/scala/boopickle/Default.scala
@@ -56,7 +56,7 @@ trait TransformPicklers {
    * @tparam B Type for the object used for pickling
    */
   def transformPickler[A <: AnyRef, B](transformTo: (A) => B, transformFrom: (B) => A)(implicit p: Pickler[B]) = {
-    p.map(transformTo)(transformFrom)
+    p.xmap(transformFrom)(transformTo)
   }
 }
 

--- a/boopickle/shared/src/main/scala/boopickle/Pickler.scala
+++ b/boopickle/shared/src/main/scala/boopickle/Pickler.scala
@@ -12,7 +12,7 @@ trait Pickler[A] {
   def pickle(obj: A)(implicit state: PickleState)
   def unpickle(implicit state: UnpickleState): A
 
-  def map[B](ba: B => A)(ab: A => B): Pickler[B] = {
+  def xmap[B](ab: A => B)(ba: B => A): Pickler[B] = {
     val self = this
     new Pickler[B] {
       override def unpickle(implicit state: UnpickleState): B = {


### PR DESCRIPTION
`xmap[B](ba: B => A)(ab: A => B)` ←instead of this
`xmap[B](ab: A => B)(ba: B => A)` ←this gives better type-inference because `A` is already known.

Type-inference is good at working out the output of a function but terrible at working of the input of a function (in fact the scalac guys just hardcoded a few hacks here and there cos they found it too hard due to subtyping).
