### PR TITLE
Expose addImmutableRef & immutableFor in UnpicklerState

### DIFF
--- a/boopickle/shared/src/main/scala/boopickle/Pickler.scala
+++ b/boopickle/shared/src/main/scala/boopickle/Pickler.scala
@@ -520,12 +520,12 @@ final class UnpickleState(val dec: Decoder) {
   addImmutableRef(null)
   Constants.immutableInitData.foreach(addImmutableRef)
 
-  @inline private[boopickle] def immutableFor[A <: AnyRef](ref: Int): A = {
+  @inline def immutableFor[A <: AnyRef](ref: Int): A = {
     assert(ref > 0)
     immutableRefs(ref).asInstanceOf[A]
   }
 
-  @inline private[boopickle] def addImmutableRef(obj: AnyRef): Unit = {
+  @inline def addImmutableRef(obj: AnyRef): Unit = {
     immutableRefs += obj
   }
 


### PR DESCRIPTION
I have lots of data that I know to be immutable and safe to store in an `AnyRefMap`.

I see that `PicklerState` gives me access to `immutableRefFor` & `addImmutableRef` yet when I tried to use them in the Unpickler I found they were private.