### PR TITLE
Pushka perftests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -112,8 +112,10 @@ lazy val perftests = crossProject
     scalacOptions ++= Seq("-Xstrict-inference"),
     libraryDependencies ++= Seq(
       "com.lihaoyi" %%% "upickle" % "0.3.4",
-      "com.github.benhutchison" %%% "prickle" % "1.1.6"
-    )
+      "com.github.benhutchison" %%% "prickle" % "1.1.6",
+      "com.github.fomkin" %%% "pushka-json" % "0.2.0"
+    ),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full)
   )
   .jsSettings(
     bootSnippet := "BooApp().main();",

--- a/perftests/shared/src/main/scala/boopickle/perftests/PushkaRunners.scala
+++ b/perftests/shared/src/main/scala/boopickle/perftests/PushkaRunners.scala
@@ -1,0 +1,42 @@
+package boopickle.perftests
+
+import java.nio.charset.StandardCharsets
+
+import pushka.{Reader, Writer}
+import pushka.json._
+
+abstract class PushkaRunner[A](data: A) extends TestRunner[A](data) {
+  override def name = "Pushka"
+}
+
+object PushkaRunners {
+
+  def encodeRunner[A](data:A)(implicit p: Writer[A], u:Reader[A]):PushkaRunner[A] = new PushkaRunner[A](data) {
+    var testData : A = _
+
+    override def initialize = {
+      testData = data
+      val res = write(testData)
+      res.getBytes(StandardCharsets.UTF_8)
+    }
+
+    override def run = {
+      write(testData)
+    }
+  }
+
+  def decodeRunner[A](data:A)(implicit p:Writer[A], u:Reader[A]):PushkaRunner[A] = new PushkaRunner[A](data) {
+    var testData : A = _
+    var s:String = _
+
+    override def initialize = {
+      testData = data
+      s = write(testData)
+      s.getBytes(StandardCharsets.UTF_8)
+    }
+
+    override def run = {
+      read[A](s)
+    }
+  }
+}

--- a/perftests/shared/src/main/scala/boopickle/perftests/TestData.scala
+++ b/perftests/shared/src/main/scala/boopickle/perftests/TestData.scala
@@ -2,8 +2,14 @@ package boopickle.perftests
 
 import java.util.UUID
 
-import scala.collection.mutable
 import scala.util.Random
+import pushka.annotation._
+
+@pushka
+case class Book(id: String, name: String, author: String, publicationYear: Int)
+
+@pushka
+case class Node(name:String, color:String, children:Seq[Node])
 
 object TestData {
   val uuids = {
@@ -15,8 +21,6 @@ object TestData {
     uuidIdx = (uuidIdx + 1) % uuids.size
     uuids(uuidIdx)
   }
-
-  case class Book(id: String, name: String, author: String, publicationYear: Int)
 
   def books(idGen:  => String): Seq[Book] = Seq(
     Book(idGen, "Carrie", "Stephen King", 1974),
@@ -66,8 +70,6 @@ object TestData {
     val r = new Random(0)
     for(i <- 0 until 1000) yield (r.nextDouble()-0.1)*1e6
   }
-
-  case class Node(name:String, color:String, children:Seq[Node])
 
   val colors = Seq("black", "red", "white", "yellow", "blue")
 

--- a/perftests/shared/src/main/scala/boopickle/perftests/Tests.scala
+++ b/perftests/shared/src/main/scala/boopickle/perftests/Tests.scala
@@ -1,6 +1,7 @@
 package boopickle.perftests
 
 import boopickle.Default._
+import pushka.json._
 
 object Tests {
   val tree = TestData.genTree(5, 3)
@@ -8,92 +9,110 @@ object Tests {
     PerfTestSuite("Encode single Seq[Int]", Seq(
       BooPickleRunners.encodeRunner(Seq(3)),
       PrickleRunners.encodeRunner(Seq(3)),
-      UPickleRunners.encodeRunner(Seq(3))
+      UPickleRunners.encodeRunner(Seq(3)),
+      PushkaRunners.encodeRunner(Seq(3))
     )),
     PerfTestSuite("Decode single Seq[Int]", Seq(
       BooPickleRunners.decodeRunner(Seq(3)),
       PrickleRunners.decodeRunner(Seq(3)),
-      UPickleRunners.decodeRunner(Seq(3))
+      UPickleRunners.decodeRunner(Seq(3)),
+      PushkaRunners.decodeRunner(Seq(3))
     )),
     PerfTestSuite("Encode very large Seq[Int]", Seq(
       BooPickleRunners.encodeRunner(TestData.largeIntSeq),
       PrickleRunners.encodeRunner(TestData.largeIntSeq),
-      UPickleRunners.encodeRunner(TestData.largeIntSeq)
+      UPickleRunners.encodeRunner(TestData.largeIntSeq),
+      PushkaRunners.encodeRunner(TestData.largeIntSeq)
     )),
     PerfTestSuite("Decode very large Seq[Int]", Seq(
       BooPickleRunners.decodeRunner(TestData.largeIntSeq),
       PrickleRunners.decodeRunner(TestData.largeIntSeq),
-      UPickleRunners.decodeRunner(TestData.largeIntSeq)
+      UPickleRunners.decodeRunner(TestData.largeIntSeq),
+      PushkaRunners.decodeRunner(TestData.largeIntSeq)
     )),
     PerfTestSuite("Encode large Seq[Double]", Seq(
       BooPickleRunners.encodeRunner(TestData.largeDoubleSeq),
       PrickleRunners.encodeRunner(TestData.largeDoubleSeq),
-      UPickleRunners.encodeRunner(TestData.largeDoubleSeq)
+      UPickleRunners.encodeRunner(TestData.largeDoubleSeq),
+      PushkaRunners.encodeRunner(TestData.largeDoubleSeq)
     )),
     PerfTestSuite("Decode large Seq[Double]", Seq(
       BooPickleRunners.decodeRunner(TestData.largeDoubleSeq),
       PrickleRunners.decodeRunner(TestData.largeDoubleSeq),
-      UPickleRunners.decodeRunner(TestData.largeDoubleSeq)
+      UPickleRunners.decodeRunner(TestData.largeDoubleSeq),
+      PushkaRunners.decodeRunner(TestData.largeDoubleSeq)
     )),
     PerfTestSuite("Encode large Seq[Float]", Seq(
       BooPickleRunners.encodeRunner(TestData.largeFloatSeq),
       PrickleRunners.encodeRunner(TestData.largeFloatSeq),
-      UPickleRunners.encodeRunner(TestData.largeFloatSeq)
+      UPickleRunners.encodeRunner(TestData.largeFloatSeq),
+      PushkaRunners.encodeRunner(TestData.largeFloatSeq)
     )),
     PerfTestSuite("Decode large Seq[Float]", Seq(
       BooPickleRunners.decodeRunner(TestData.largeFloatSeq),
       PrickleRunners.decodeRunner(TestData.largeFloatSeq),
-      UPickleRunners.decodeRunner(TestData.largeFloatSeq)
+      UPickleRunners.decodeRunner(TestData.largeFloatSeq),
+      PushkaRunners.decodeRunner(TestData.largeFloatSeq)
     )),
     PerfTestSuite("Encode an object tree", Seq(
       BooPickleRunners.encodeRunner(tree),
       PrickleRunners.encodeRunner(tree),
-      UPickleRunners.encodeRunner(tree)
+      UPickleRunners.encodeRunner(tree),
+      PushkaRunners.encodeRunner(tree)
     )),
     PerfTestSuite("Decode an object tree", Seq(
       BooPickleRunners.decodeRunner(tree),
       PrickleRunners.decodeRunner(tree),
-      UPickleRunners.decodeRunner(tree)
+      UPickleRunners.decodeRunner(tree),
+      PushkaRunners.decodeRunner(tree)
     )),
     PerfTestSuite("Encode very large Map[String, Int]", List(
       BooPickleRunners.encodeRunner(TestData.largeStringIntMap),
       PrickleRunners.encodeRunner(TestData.largeStringIntMap),
-      UPickleRunners.encodeRunner(TestData.largeStringIntMap)
+      UPickleRunners.encodeRunner(TestData.largeStringIntMap),
+      PushkaRunners.encodeRunner(TestData.largeStringIntMap)
     )),
     PerfTestSuite("Decode very large Map[String, Int]", List(
       BooPickleRunners.decodeRunner(TestData.largeStringIntMap),
       PrickleRunners.decodeRunner(TestData.largeStringIntMap),
-      UPickleRunners.decodeRunner(TestData.largeStringIntMap)
+      UPickleRunners.decodeRunner(TestData.largeStringIntMap),
+      PushkaRunners.decodeRunner(TestData.largeStringIntMap)
     )),
     PerfTestSuite("Encoding Seq[Book] with random IDs", Seq(
       BooPickleRunners.encodeRunner(TestData.booksRandomID),
       PrickleRunners.encodeRunner(TestData.booksRandomID),
-      UPickleRunners.encodeRunner(TestData.booksRandomID)
+      UPickleRunners.encodeRunner(TestData.booksRandomID),
+      PushkaRunners.encodeRunner(TestData.booksRandomID)
     )),
     PerfTestSuite("Decoding Seq[Book] with random IDs", Seq(
       BooPickleRunners.decodeRunner(TestData.booksRandomID),
       PrickleRunners.decodeRunner(TestData.booksRandomID),
-      UPickleRunners.decodeRunner(TestData.booksRandomID)
+      UPickleRunners.decodeRunner(TestData.booksRandomID),
+      PushkaRunners.decodeRunner(TestData.booksRandomID)
     )),
     PerfTestSuite("Encoding Seq[Book] with UUIDs", Seq(
       BooPickleRunners.encodeRunner(TestData.booksUUID),
       PrickleRunners.encodeRunner(TestData.booksUUID),
-      UPickleRunners.encodeRunner(TestData.booksUUID)
+      UPickleRunners.encodeRunner(TestData.booksUUID),
+      PushkaRunners.encodeRunner(TestData.booksUUID)
     )),
     PerfTestSuite("Decoding Seq[Book] with UUIDs", Seq(
       BooPickleRunners.decodeRunner(TestData.booksUUID),
       PrickleRunners.decodeRunner(TestData.booksUUID),
-      UPickleRunners.decodeRunner(TestData.booksUUID)
+      UPickleRunners.decodeRunner(TestData.booksUUID),
+      PushkaRunners.decodeRunner(TestData.booksUUID)
     )),
     PerfTestSuite("Encoding Seq[Book] with numerical IDs", Seq(
       BooPickleRunners.encodeRunner(TestData.booksNumId),
       PrickleRunners.encodeRunner(TestData.booksNumId),
-      UPickleRunners.encodeRunner(TestData.booksNumId)
+      UPickleRunners.encodeRunner(TestData.booksNumId),
+      PushkaRunners.encodeRunner(TestData.booksNumId)
     )),
     PerfTestSuite("Decoding Seq[Book] with numerical IDs", Seq(
       BooPickleRunners.decodeRunner(TestData.booksNumId),
       PrickleRunners.decodeRunner(TestData.booksNumId),
-      UPickleRunners.decodeRunner(TestData.booksNumId)
+      UPickleRunners.decodeRunner(TestData.booksNumId),
+      PushkaRunners.decodeRunner(TestData.booksNumId)
     ))
   )
 }


### PR DESCRIPTION
Here it is.
```
1/18 : Encode single Seq[Int]
=============================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  410248     8,4%       2          100%       22         100%      
Prickle    304844     6,2%       29         1450%      47         214%      
uPickle    1637897    33,4%      3          150%       23         105%      
Pushka     4909218    100,0%     3          150%       23         105%      

2/18 : Decode single Seq[Int]
=============================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  3053414    100,0%     2          100%       22         100%      
Prickle    25510      0,8%       29         1450%      47         214%      
uPickle    805802     26,4%      3          150%       23         105%      
Pushka     1879348    61,5%      3          150%       23         105%      

3/18 : Encode very large Seq[Int]
=================================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  4982       100,0%     18084      100%       14613      100%      
Prickle    724        14,5%      71180      394%       18368      126%      
uPickle    658        13,2%      41157      228%       16665      114%      
Pushka     1282       25,7%      41157      228%       16665      114%      

4/18 : Decode very large Seq[Int]
=================================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  3640       100,0%     18084      100%       14613      100%      
Prickle    223        6,1%       71180      394%       18368      126%      
uPickle    576        15,8%      41157      228%       16665      114%      
Pushka     778        21,4%      41157      228%       16665      114%      

5/18 : Encode large Seq[Double]
===============================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  43438      100,0%     8002       100%       7688       100%      
Prickle    2304       5,3%       19342      242%       9993       130%      
uPickle    2148       4,9%       18319      229%       9780       127%      
Pushka     2542       5,9%       18319      229%       9780       127%      

6/18 : Decode large Seq[Double]
===============================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  37530      100,0%     8002       100%       7688       100%      
Prickle    964        2,6%       19342      242%       9993       130%      
uPickle    2480       6,6%       18319      229%       9780       127%      
Pushka     2756       7,3%       18319      229%       9780       127%      

7/18 : Encode large Seq[Float]
==============================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  50642      100,0%     4002       100%       3659       100%      
Prickle    2288       4,5%       19031      476%       6872       188%      
uPickle    2118       4,2%       18006      450%       6743       184%      
Pushka     2382       4,7%       18006      450%       6743       184%      

8/18 : Decode large Seq[Float]
==============================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  54448      100,0%     4002       100%       3659       100%      
Prickle    1066       2,0%       19031      476%       6872       188%      
uPickle    2288       4,2%       18006      450%       6743       184%      
Pushka     2542       4,7%       18006      450%       6743       184%      

9/18 : Encode an object tree
============================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  1326       68,5%      3544       100%       1715       100%      
Prickle    379        19,6%      35481      1001%      4169       243%      
uPickle    1630       84,2%      20385      575%       2245       131%      
Pushka     1936       100,0%     20385      575%       2245       131%      

10/18 : Decode an object tree
=============================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  6314       100,0%     3544       100%       1715       100%      
Prickle    98         1,6%       35481      1001%      4169       243%      
uPickle    1564       24,8%      20385      575%       2245       131%      
Pushka     3752       59,4%      20385      575%       2245       131%      

11/18 : Encode very large Map[String, Int]
==========================================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  350        83,9%      86974      100%       45404      100%      
Prickle    253        60,7%      190070     219%       47909      106%      
uPickle    417        100,0%     130047     150%       45263      100%      
Pushka     243        58,3%      150047     173%       46538      103%      

12/18 : Decode very large Map[String, Int]
==========================================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  314        100,0%     86974      100%       45404      100%      
Prickle    67         21,3%      190070     219%       47909      106%      
uPickle    214        68,2%      130047     150%       45263      100%      
Pushka     191        60,8%      150047     173%       46538      103%      

13/18 : Encoding Seq[Book] with random IDs
==========================================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  103612     96,9%      266        100%       243        100%      
Prickle    29372      27,5%      935        352%       325        134%      
uPickle    90568      84,7%      736        277%       285        117%      
Pushka     106882     100,0%     736        277%       285        117%      

14/18 : Decoding Seq[Book] with random IDs
==========================================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  358134     100,0%     266        100%       243        100%      
Prickle    7136       2,0%       935        352%       325        134%      
uPickle    82178      22,9%      736        277%       285        117%      
Pushka     126350     35,3%      736        277%       285        117%      

15/18 : Encoding Seq[Book] with UUIDs
=====================================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  37998      38,9%      306        100%       317        100%      
Prickle    25494      26,1%      1135       371%       461        145%      
uPickle    86432      88,5%      936        306%       415        131%      
Pushka     97680      100,0%     936        306%       415        131%      

16/18 : Decoding Seq[Book] with UUIDs
=====================================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  118828     99,5%      306        100%       317        100%      
Prickle    8032       6,7%       1135       371%       461        145%      
uPickle    85340      71,5%      936        306%       415        131%      
Pushka     119374     100,0%     936        306%       415        131%      

17/18 : Encoding Seq[Book] with numerical IDs
=============================================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  128684     100,0%     194        100%       187        100%      
Prickle    32496      25,3%      879        453%       276        148%      
uPickle    98838      76,8%      680        351%       234        125%      
Pushka     113340     88,1%      680        351%       234        125%      

18/18 : Decoding Seq[Book] with numerical IDs
=============================================
Library    ops/s      %          size       %          size.gz    %         
BooPickle  373952     100,0%     194        100%       187        100%      
Prickle    8030       2,1%       879        453%       276        148%      
uPickle    90840      24,3%      680        351%       234        125%      
Pushka     134042     35,8%      680        351%       234        125%    
```