### PR TITLE
Make it possible to use transformPickler upon value classes.

### DIFF
--- a/boopickle/shared/src/main/scala/boopickle/Default.scala
+++ b/boopickle/shared/src/main/scala/boopickle/Default.scala
@@ -56,7 +56,7 @@ trait TransformPicklers {
    * @tparam A Type of the original object
    * @tparam B Type for the object used for pickling
    */
-  def transformPickler[A <: AnyRef, B](transformTo: (A) => B, transformFrom: (B) => A)(implicit p: Pickler[B]) = {
+  def transformPickler[A, B](transformTo: (A) => B, transformFrom: (B) => A)(implicit p: Pickler[B]) = {
     p.xmap(transformFrom)(transformTo)
   }
 }


### PR DESCRIPTION
Value classes extend AnyVal but transformPickler requires AnyRef making it impossible to easily pickle classes like for example this one:
implicit final class Uptime(val toNanos: Long = System.nanoTime) extends AnyVal {
}

The better option would be to pickle/unpickle value classes automatically by the macro. But this patch is a good start ;).
It just changes the signature of transformPickler to match Pickler.xmap signature which permits Any instead of AnyRef.