### PR TITLE
Fix for "Unknown type: (self: Object)Object, (self: Object)Object [cl…

### DIFF
--- a/boopickle/shared/src/main/scala/boopickle/Pickler.scala
+++ b/boopickle/shared/src/main/scala/boopickle/Pickler.scala
@@ -503,7 +503,7 @@ final class PickleState(val enc: Encoder) {
   @inline def identityRefFor(obj: AnyRef) = identityRefs.get(Identity(obj))
 
   @inline def addIdentityRef(obj: AnyRef): Unit = {
-    identityRefs += Identity(obj) -> identityIdx
+    identityRefs += ((Identity(obj), identityIdx))
     identityIdx += 1
   }
 


### PR DESCRIPTION
…ass scala.reflect.internal.Types$MethodType, class scala.reflect.internal.Types$MethodType] TypeRef? false" error.

Strange error that occurs in the following setup:
scalaVersion := "2.11.7",
scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-optimize", "-Xlint", "-Ywarn-infer-any", "-Ywarn-nullary-unit", "-Ywarn-dead-code", "-Ywarn-unused", "-encoding", "UTF-8"),
addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

And it either fixes the way it is fixed in this patch or by removing @inline from addIdentityRef.