### PR TITLE
Fix for #49

### DIFF
--- a/boopickle/shared/src/main/scala/boopickle/Pickler.scala
+++ b/boopickle/shared/src/main/scala/boopickle/Pickler.scala
@@ -151,7 +151,7 @@ object BasicPicklers extends PicklerHelper {
           // encode index as negative "length"
           state.enc.writeInt(-idx)
         case None =>
-          if (s.length > 1 && s.length < 21 && (s(0).isDigit || s(0) == '-') && numRE.pattern.matcher(s).matches()) {
+          if (s.length > 1 && ((s(0).isDigit && s.length < 19) || (s(0) == '-' && s.length < 20)) && numRE.pattern.matcher(s).matches()) {
             // string represents an integer/long
             try {
               val l = java.lang.Long.parseLong(s)

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,3 +1,3 @@
 object Version {
-  val library = "1.1.2"
+  val library = "1.1.3-SNAPSHOT"
 }


### PR DESCRIPTION
A string with value "13065136436328809018" got decoded "-5381607637380742598". I corrected the string length checks to always fit within
Long.MAX_VALUE =  9223372036854775807
Long.MIN_VALUE = -9223372036854775808