### PR TITLE
Support null UUIDs

### DIFF
--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,3 +1,3 @@
 object Version {
-  val library = "1.1.2"
+  val library = "1.1.3-SNAPSHOT"
 }


### PR DESCRIPTION
ran into an issue using BooPickle, since (due to legacy code) we have objects with `null` `UUID` fields going across the wire. Switched `UUIDPickler` to using immutableRefs.

Cons
  - UUIDs grow by 1 byte.

Pros
  - null UUIDs don't crash.
  - our datamodel happens to often push many repeated UUIDs in one message (for instance a message with a "parent" object and many "child" objects, all children containing the parent UUID and other UUIDs that will be the same across them), so data savings for us

I recognize that most people will probably only ever send unique UUIDs across the wire, and they're not going to be `null`, but seems like going from 16 bytes to 17 isn't the end of the world.