### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # BooPickle
 
 [![Build Status](https://travis-ci.org/ochrons/boopickle.svg?branch=master)](https://travis-ci.org/ochrons/boopickle)
-[![Scala.js](http://scala-js.org/assets/badges/scalajs-0.6.6.svg)](http://scala-js.org)
+[![Scala.js](http://www.scala-js.org/assets/badges/scalajs-0.6.6.svg)](http://www.scala-js.org/)
 
 BooPickle is the [fastest](http://ochrons.github.io/boopickle-perftest/) and most size efficient serialization (aka pickling) library for Scala 
 and [Scala.js](http://www.scala-js.org). It encodes into a binary format instead of the more customary JSON. A binary format brings efficiency 
-gains in both size and speed, at the cost of legibility of the encoded data. BooPickle borrows heavily from both [uPickle](https://github.com/lihaoyi/upickle) 
+gains in both size and speed, at the cost of legibility of the encoded data. BooPickle borrows heavily from both [uPickle](https://github.com/lihaoyi/upickle-pprint) 
 and [Prickle](https://github.com/benhutchison/prickle) so special thanks to Li Haoyi and Ben Hutchison for those two great libraries!
 
 ## Features


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/lihaoyi/upickle | https://github.com/lihaoyi/upickle-pprint 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://scala-js.org | http://www.scala-js.org/ 
http://scala-js.org/assets/badges/scalajs-0.6.6.svg | http://www.scala-js.org/assets/badges/scalajs-0.6.6.svg 
