### PR TITLE
Improve documentation when unpickling class hierarchies

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ assert(u == fruits)
 
 Note that internally `CompositePickler` encodes types using indices, so they must be specified in the same order on both sides!
 
+BooPickle needs to know the type when pickling to do deserialize to the correct type, thus this fails
+
+```scala
+val b = Banana(1.0)
+val bb = Pickle.intoBytes(b)
+assert(Unpickle[Banana].fromBytes(bb) == b) // This produces Banana
+val bb2 = Pickle.intoBytes(b)
+assert(Unpickle[Fruit].fromBytes(bb2) == null) // This produces null
+```
+
+Instead when pickling declare the parent type
+
+```scala
+val f: Fruit = Banana(1.0)
+val bf = Pickle.intoBytes(f)
+assert(Unpickle[Fruit].fromBytes(bf) == f) // This produces a Fruit
+```
+
 ### Recursive composite types
 
 If you have a recursive composite type (a sub type has a reference to the super type), you need to build the `CompositePickler` in two steps,

--- a/boopickle/shared/src/test/scala/external/CompositePickleTests.scala
+++ b/boopickle/shared/src/test/scala/external/CompositePickleTests.scala
@@ -62,13 +62,27 @@ final case class OwnerAttribute(owner: String, parent: Element) extends Attribut
 
 object CompositePickleTests extends TestSuite {
   override def tests = TestSuite {
-    'CaseClassHierarchy {
+    'CaseClassHierarchySeq {
       implicit val fruitPickler = compositePickler[Fruit].addConcreteType[Banana].addConcreteType[Kiwi].addConcreteType[Carambola]
 
       val fruits: Seq[Fruit] = Seq(Kiwi(0.5), Kiwi(0.6), Carambola(5.0), Banana(1.2))
       val bb = Pickle.intoBytes(fruits)
       val u = Unpickle[Seq[Fruit]].fromBytes(bb)
       assert(u == fruits)
+    }
+    'CaseClassHierarchy {
+      implicit val fruitPickler = compositePickler[Fruit].addConcreteType[Banana].addConcreteType[Kiwi].addConcreteType[Carambola]
+
+      val b = Banana(1.0)
+      val bb = Pickle.intoBytes(b)
+      assert(Unpickle[Banana].fromBytes(bb) == b) // This produces Banana
+      val bb2 = Pickle.intoBytes(b)
+      assert(Unpickle[Fruit].fromBytes(bb2) == null) // This produces null
+
+      // Instead pickle with the parent's type
+      val f: Fruit = Banana(1.0)
+      val bf = Pickle.intoBytes(f)
+      assert(Unpickle[Fruit].fromBytes(bf) == f) // This produces a Fruit
     }
     'CaseObjects {
       implicit val errorPickler = compositePickler[Error].addConcreteType[InvalidName.type].addConcreteType[Unknown.type].addConcreteType[NotFound.type]


### PR DESCRIPTION
This is a little PR adding some documentation when unpickling a class hierarchy. A test case was added for the described situation. This closes #57 