### PR TITLE
Xfatal warnings

### DIFF
--- a/boopickle/js/src/main/scala/boopickle/StringCodec.scala
+++ b/boopickle/js/src/main/scala/boopickle/StringCodec.scala
@@ -79,7 +79,7 @@ object StringCodec extends StringCodecFuncs {
     val ta = new Uint16Array(s.length)
     var i = 0
     while (i < s.length) {
-      ta(i) = s.charAt(i).toShort
+      ta(i) = s.charAt(i).toInt
       i += 1
     }
     TypedArrayBuffer.wrap(new Int8Array(ta.buffer))

--- a/boopickle/shared/src/main/scala/boopickle/CodecSize.scala
+++ b/boopickle/shared/src/main/scala/boopickle/CodecSize.scala
@@ -107,7 +107,7 @@ class DecoderSize(val buf: ByteBuffer) extends Decoder {
     val b = buf.get & 0xFF
     if (b != 0xE1) {
       buf.position(buf.position - 1)
-      readInt
+      readInt.toLong
     } else {
       readRawLong
     }

--- a/boopickle/shared/src/main/scala/boopickle/CompositePicklers.scala
+++ b/boopickle/shared/src/main/scala/boopickle/CompositePicklers.scala
@@ -13,7 +13,7 @@ case class CompositePickler[A <: AnyRef](var picklers: Vector[(String, Pickler[_
 
   override def pickle(obj: A)(implicit state: PickleState): Unit = {
     if (obj == null) {
-      state.enc.writeInt(CompositeNull)
+      state.enc.writeInt(CompositeNull.toInt)
     } else {
       val name = obj.getClass.getName
       val idx = picklers.indexWhere(_._1 == name)
@@ -46,11 +46,12 @@ case class CompositePickler[A <: AnyRef](var picklers: Vector[(String, Pickler[_
     this
   }
 
-  def addException[B <: A with Throwable](ctor: (String) => B)(implicit tag: ClassTag[B]) = {
+  def addException[B <: A with Throwable](ctor: (String) => B)(implicit tag: ClassTag[B]): CompositePickler[A] = {
     val pickler = new Pickler[B] {
       override def pickle(ex: B)(implicit state: PickleState): Unit = {
         state.pickle(ex.getMessage)
       }
+
       override def unpickle(implicit state: UnpickleState): B = {
         ctor(state.unpickle[String])
       }
@@ -59,7 +60,7 @@ case class CompositePickler[A <: AnyRef](var picklers: Vector[(String, Pickler[_
     this
   }
 
-  def join[B <: A](implicit cp: CompositePickler[B]) = {
+  def join[B <: A](implicit cp: CompositePickler[B]): CompositePickler[A] = {
     picklers ++= cp.picklers
     this
   }

--- a/boopickle/shared/src/main/scala/boopickle/PicklerMaterializersImpl.scala
+++ b/boopickle/shared/src/main/scala/boopickle/PicklerMaterializersImpl.scala
@@ -94,9 +94,9 @@ object PicklerMaterializersImpl {
       val pickleFields = for {
         accessor <- accessors
       } yield {
-          val fieldTpe = accessor.typeSignatureIn(tpe).finalResultType
-          q"""state.pickle[$fieldTpe](value.${accessor.name})"""
-        }
+        val fieldTpe = accessor.typeSignatureIn(tpe).finalResultType
+        q"""state.pickle[$fieldTpe](value.${accessor.name})"""
+      }
 
       q"""
           val ref = state.identityRefFor(value)
@@ -120,9 +120,9 @@ object PicklerMaterializersImpl {
       val unpickledFields = for {
         accessor <- accessors
       } yield {
-          val fieldTpe = accessor.typeSignatureIn(tpe).finalResultType
-          q"""state.unpickle[$fieldTpe]"""
-        }
+        val fieldTpe = accessor.typeSignatureIn(tpe).finalResultType
+        q"""state.unpickle[$fieldTpe]"""
+      }
       q"""
           val ic = state.dec.readInt
           if(ic == 0) {
@@ -141,7 +141,7 @@ object PicklerMaterializersImpl {
 
     val result = q"""
       implicit object $name extends boopickle.Pickler[$tpe] {
-        override def pickle(value: $tpe)(implicit state: boopickle.PickleState): Unit = $pickleLogic
+        override def pickle(value: $tpe)(implicit state: boopickle.PickleState): Unit = { $pickleLogic; () }
         override def unpickle(implicit state: boopickle.UnpickleState): $tpe = $unpickleLogic
       }
       $name

--- a/boopickle/shared/src/test/scala/boopickle/CodecTests.scala
+++ b/boopickle/shared/src/test/scala/boopickle/CodecTests.scala
@@ -33,38 +33,38 @@ object CodecTests extends TestSuite {
   override def tests = TestSuite {
     'Byte - {
       val data = Seq[Byte](0, 1, -128, 127, -1)
-      runCodec[Byte](data, (e, x) => e.writeByte(x), (d, x) => d.readByte == x)
+      runCodec[Byte](data, (e, x) => { e.writeByte(x); () }, (d, x) => d.readByte == x)
     }
 
     'Int - {
       val data = Seq(0, 1, -1, 4095, -4096, -4097, -4098, -4099, 4096, 4097, 4098, 4099, 1048575, 1048576, -1048576, -1048577, 268435455, 268435456, -268435456, -268435457, Int.MaxValue, Int.MinValue)
-      runCodec[Int](data, (e, x) => e.writeInt(x), (d, x) => d.readInt == x)
+      runCodec[Int](data, (e, x) => { e.writeInt(x); () }, (d, x) => d.readInt == x)
     }
 
     'Long - {
       val data = Seq[Long](0, 1, -1, -4096, -4097, 4096, 1048575, 1048576, -1048576, -1048577, Int.MaxValue, Int.MinValue,
         Int.MaxValue + 1, Int.MinValue - 1, Long.MaxValue, Long.MinValue)
-      runCodec[Long](data, (e, x) => e.writeLong(x), (d, x) => d.readLong == x)
+      runCodec[Long](data, (e, x) => { e.writeLong(x); () }, (d, x) => d.readLong == x)
     }
 
     'Float - {
       val data = Seq[Float](0.0f, 1.0f, -0.5f, Float.MaxValue, Float.MinValue, Float.NegativeInfinity, Float.PositiveInfinity)
-      runCodec[Float](data, (e, x) => e.writeFloat(x), (d, x) => d.readFloat == x)
+      runCodec[Float](data, (e, x) => { e.writeFloat(x); () }, (d, x) => d.readFloat == x)
     }
 
     'Double - {
       val data = Seq[Double](0.0, 1.0, -0.5, Double.MaxValue, Double.MinValue, Double.NegativeInfinity, Double.PositiveInfinity)
-      runCodec[Double](data, (e, x) => e.writeDouble(x), (d, x) => d.readDouble == x)
+      runCodec[Double](data, (e, x) => { e.writeDouble(x); () }, (d, x) => d.readDouble == x)
     }
 
     'Char - {
       val data = Seq[Char](' ', 'A', 'Ö', '叉', '€')
-      runCodec[Char](data, (e, x) => e.writeChar(x), (d, x) => d.readChar == x)
+      runCodec[Char](data, (e, x) => { e.writeChar(x); () }, (d, x) => d.readChar == x)
     }
 
     'String - {
       val data = Seq[String]("", "A", "叉", "Normal String", "Arabic ڞ", "Complex \uD840\uDC00\uD841\uDDA7")
-      runCodec[String](data, (e, x) => e.writeString(x), (d, x) => d.readString == x)
+      runCodec[String](data, (e, x) => { e.writeString(x); () }, (d, x) => d.readString == x)
     }
 
     'ByteBuffer - {
@@ -81,22 +81,22 @@ object CodecTests extends TestSuite {
 
     'ByteArray - {
       val ba = Seq(Array[Byte](0, 127, -128, -1, 1), Array[Byte]())
-      runCodec[Array[Byte]](ba, (e, x) => e.writeByteArray(x), (d, x) => d.readByteArray.sameElements(x))
+      runCodec[Array[Byte]](ba, (e, x) => { e.writeByteArray(x); () }, (d, x) => d.readByteArray.sameElements(x))
     }
 
     'IntArray - {
       val ba = Seq(Array[Int](0, Int.MaxValue, Int.MinValue, -1, 1, 256, 65536), Array[Int]())
-      runCodec[Array[Int]](ba, (e, x) => e.writeIntArray(x), (d, x) => d.readIntArray.sameElements(x))
+      runCodec[Array[Int]](ba, (e, x) => { e.writeIntArray(x); () }, (d, x) => d.readIntArray.sameElements(x))
     }
 
     'FloatArray - {
       val ba = Seq(Array[Float](0, Float.MaxValue, Float.MinValue, -1, 1, 256.0f, 65536.0f), Array[Float]())
-      runCodec[Array[Float]](ba, (e, x) => e.writeFloatArray(x), (d, x) => d.readFloatArray.sameElements(x))
+      runCodec[Array[Float]](ba, (e, x) => { e.writeFloatArray(x); () }, (d, x) => d.readFloatArray.sameElements(x))
     }
 
     'DoubleArray - {
       val ba = Seq(Array[Double](0, Double.MaxValue, Double.MinValue, -1, 1, 256.0, 65536.0), Array[Double]())
-      runCodec[Array[Double]](ba, (e, x) => e.writeDoubleArray(x), (d, x) => d.readDoubleArray.sameElements(x))
+      runCodec[Array[Double]](ba, (e, x) => { e.writeDoubleArray(x); () }, (d, x) => d.readDoubleArray.sameElements(x))
     }
   }
 }

--- a/boopickle/shared/src/test/scala/external/PickleTests.scala
+++ b/boopickle/shared/src/test/scala/external/PickleTests.scala
@@ -383,7 +383,7 @@ object PickleTests extends TestSuite {
         'tuple2 {
           val bb = Pickle.intoBytes(("Hello", Some("World")))
           assert(bb.limit == 6 + 1 + 6)
-          assert(Unpickle[(String, Option[String])].fromBytes(bb) ==("Hello", Some("World")))
+          assert(Unpickle[(String, Option[String])].fromBytes(bb) == (("Hello", Some("World"))))
         }
       }
       'Seq - {
@@ -922,7 +922,7 @@ object PickleTests extends TestSuite {
         'tuple2 {
           val bb = Pickle.intoBytes(("Hello", Some("World")))
           assert(bb.limit == 4 + 5 * 2 + 4 + 4 + 5 * 2)
-          assert(Unpickle[(String, Option[String])].fromBytes(bb) ==("Hello", Some("World")))
+          assert(Unpickle[(String, Option[String])].fromBytes(bb) == (("Hello", Some("World"))))
         }
       }
       'Seq - {

--- a/build.sbt
+++ b/build.sbt
@@ -5,11 +5,24 @@ import com.typesafe.sbt.pgp.PgpKeys._
 val commonSettings = Seq(
   organization := "me.chrons",
   version := Version.library,
-  scalaVersion := "2.11.6",
-  scalacOptions ++= Seq("-unchecked", "-feature", "-deprecation", "-encoding", "utf8"),
+  scalaVersion := "2.11.8",
+  scalacOptions := Seq(
+    "-deprecation",
+    "-encoding", "UTF-8",
+    "-feature",
+    "-unchecked",
+    "-Xfatal-warnings",
+    "-Xlint",
+    "-Yinline-warnings",
+    "-Yno-adapted-args",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen",
+    "-Ywarn-value-discard",
+    "-Xfuture"),
+  scalacOptions in Compile ~= (_ filterNot (_ == "-Ywarn-value-discard")),
   testFrameworks += new TestFramework("utest.runner.Framework"),
   libraryDependencies ++= Seq(
-    "com.lihaoyi" %%% "utest" % "0.3.1" % "test",
+    "com.lihaoyi" %%% "utest" % "0.4.3" % "test",
     "com.github.japgolly.nyaya" %%% "nyaya-test" % "0.5.11" % "test",
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided"
   )
@@ -117,7 +130,7 @@ lazy val perftests = crossProject
       "io.circe" %%% "circe-parse" % "0.2.1",
       "io.circe" %%% "circe-generic" % "0.2.1"
     ),
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full)
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   )
   .jsSettings(
     bootSnippet := "BooApp().main();",

--- a/perftests/js/src/main/scala/boopickle/perftests/BooApp.scala
+++ b/perftests/js/src/main/scala/boopickle/perftests/BooApp.scala
@@ -24,7 +24,7 @@ object BooApp extends js.JSApp {
     resultsDiv.innerHTML = ""
     resultsDiv.appendChild(div(cls := "bold", s"Running ${Tests.suites.size} tests").render)
     resultsDiv.appendChild(resView)
-    def runNext(suites: Seq[PerfTestSuite]) {
+    def runNext(suites: Seq[PerfTestSuite]): Unit = {
       val suite = suites.head
       val header = s"${1 + Tests.suites.size - suites.size}/${Tests.suites.size} : ${suite.name}"
       resView.innerHTML = resView.innerHTML +  header + "\n"
@@ -50,6 +50,7 @@ object BooApp extends js.JSApp {
       else {
         resultsDiv.appendChild(h4("Completed!").render)
       }
+      ()
     }
     dom.window.setTimeout(() => runNext(Tests.suites), 10)
   }
@@ -63,5 +64,6 @@ object BooApp extends js.JSApp {
 
     contentRoot.appendChild(div(cls := "row", runButton).render)
     contentRoot.appendChild(results)
+    ()
   }
 }

--- a/perftests/shared/src/main/scala/boopickle/perftests/BoopickleRunners.scala
+++ b/perftests/shared/src/main/scala/boopickle/perftests/BoopickleRunners.scala
@@ -21,8 +21,9 @@ object BooPickleRunners {
       ba
     }
 
-    override def run = {
+    override def run(): Unit = {
       Pickle.intoBytes(testData)
+      ()
     }
   }
 
@@ -39,9 +40,10 @@ object BooPickleRunners {
       ba
     }
 
-    override def run = {
+    override def run(): Unit = {
       Unpickle[A].fromBytes(bb)
       bb.rewind()
+      ()
     }
   }
 }

--- a/perftests/shared/src/main/scala/boopickle/perftests/BoopickleSpeedRunners.scala
+++ b/perftests/shared/src/main/scala/boopickle/perftests/BoopickleSpeedRunners.scala
@@ -25,8 +25,9 @@ object BooPickleSpeedRunners {
       ba
     }
 
-    override def run = {
+    override def run(): Unit = {
       Pickle.intoBytes(testData)
+      ()
     }
   }
 
@@ -43,9 +44,10 @@ object BooPickleSpeedRunners {
       ba
     }
 
-    override def run = {
+    override def run: Unit = {
       Unpickle[A].fromBytes(bb)
       bb.rewind()
+      ()
     }
   }
 }

--- a/perftests/shared/src/main/scala/boopickle/perftests/CirceRunners.scala
+++ b/perftests/shared/src/main/scala/boopickle/perftests/CirceRunners.scala
@@ -21,8 +21,9 @@ object CirceRunners {
       res.getBytes(StandardCharsets.UTF_8)
     }
 
-    override def run = {
+    override def run(): Unit = {
       testData.asJson.noSpaces
+      ()
     }
   }
 
@@ -36,8 +37,9 @@ object CirceRunners {
       s.getBytes(StandardCharsets.UTF_8)
     }
 
-    override def run = {
+    override def run(): Unit = {
       u.decodeJson(parse.parse(s).toOption.get)
+      ()
     }
   }
 }

--- a/perftests/shared/src/main/scala/boopickle/perftests/PerfTest.scala
+++ b/perftests/shared/src/main/scala/boopickle/perftests/PerfTest.scala
@@ -18,7 +18,7 @@ abstract class TestRunner[A](val data: A) {
   /**
    * Run the test case
    */
-  def run: Unit
+  def run(): Unit
 }
 
 case class PerfTestGroupResult(name: String, results: Seq[PerfTestResult])

--- a/perftests/shared/src/main/scala/boopickle/perftests/PrickleRunners.scala
+++ b/perftests/shared/src/main/scala/boopickle/perftests/PrickleRunners.scala
@@ -20,8 +20,9 @@ object PrickleRunners {
       r.getBytes(StandardCharsets.UTF_8)
     }
 
-    override def run = {
+    override def run(): Unit = {
       Pickle.intoString(testData)
+      ()
     }
   }
 
@@ -35,8 +36,9 @@ object PrickleRunners {
       s.getBytes(StandardCharsets.UTF_8)
     }
 
-    override def run = {
+    override def run(): Unit = {
       Unpickle[A].fromString(s)
+      ()
     }
   }
 }

--- a/perftests/shared/src/main/scala/boopickle/perftests/PushkaRunners.scala
+++ b/perftests/shared/src/main/scala/boopickle/perftests/PushkaRunners.scala
@@ -20,8 +20,9 @@ object PushkaRunners {
       res.getBytes(StandardCharsets.UTF_8)
     }
 
-    override def run = {
+    override def run(): Unit = {
       write(testData)
+      ()
     }
   }
 
@@ -35,8 +36,9 @@ object PushkaRunners {
       s.getBytes(StandardCharsets.UTF_8)
     }
 
-    override def run = {
+    override def run(): Unit = {
       read[A](s)
+      ()
     }
   }
 }

--- a/perftests/shared/src/main/scala/boopickle/perftests/UpickleRunners.scala
+++ b/perftests/shared/src/main/scala/boopickle/perftests/UpickleRunners.scala
@@ -20,8 +20,9 @@ object UPickleRunners {
       res.getBytes(StandardCharsets.UTF_8)
     }
 
-    override def run = {
+    override def run(): Unit = {
       write(testData)
+      ()
     }
   }
 
@@ -35,8 +36,9 @@ object UPickleRunners {
       s.getBytes(StandardCharsets.UTF_8)
     }
 
-    override def run = {
+    override def run(): Unit = {
       read[A](s)
+      ()
     }
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.11


### PR DESCRIPTION
Boopickle leaks `discarded non-Unit value`  warnings, which prevents users from using both "-Xfatal-warnings" and "-Ywarn-value-discard" scalacOptions.

This PR adds the commonly used scalaOptions and fixes all the new compilation error reported by scalac.